### PR TITLE
Add CLI options to NDVI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # testRepo
+
+This repository contains an example Python script to calculate the Normalized Difference Vegetation Index (NDVI) using the Google Earth Engine API.
+
+## Prerequisites
+
+1. Sign up for [Google Earth Engine](https://earthengine.google.com/).
+2. Install the Earth Engine Python package:
+
+```bash
+pip install earthengine-api
+```
+
+3. Authenticate your Earth Engine account:
+
+```bash
+earthengine authenticate
+```
+
+## Running the example
+
+The script `compute_ndvi.py` demonstrates how to select a Landsat 8 image over a point of interest and compute NDVI. It prints image details and can optionally export the result to Google Drive.
+
+Run the script with arguments specifying the location and date range:
+
+```bash
+python compute_ndvi.py --lat 37.901 --lon -122.292 --start 2020-06-01 --end 2020-06-30
+```
+
+Add `--export` to send the result to Google Drive.

--- a/compute_ndvi.py
+++ b/compute_ndvi.py
@@ -1,0 +1,57 @@
+"""Compute NDVI from Landsat imagery using Google Earth Engine."""
+
+import argparse
+import ee
+
+
+def parse_args() -> argparse.Namespace:
+    """Return command line arguments."""
+    parser = argparse.ArgumentParser(description="Compute NDVI with Google Earth Engine")
+    parser.add_argument("--lat", type=float, default=37.901, help="Latitude for the AOI center")
+    parser.add_argument("--lon", type=float, default=-122.292, help="Longitude for the AOI center")
+    parser.add_argument("--start", type=str, default="2020-06-01", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end", type=str, default="2020-06-30", help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        help="Export the resulting NDVI image to Google Drive",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Initialize the Earth Engine API. Make sure you authenticated first.
+    ee.Initialize()
+
+    aoi = ee.Geometry.Point([args.lon, args.lat])
+
+    collection = (
+        ee.ImageCollection("LANDSAT/LC08/C01/T1_SR")
+        .filterDate(args.start, args.end)
+        .filterBounds(aoi)
+    )
+
+    image = collection.first()
+    if image is None:
+        raise RuntimeError("No imagery found for the specified parameters.")
+
+    ndvi = image.normalizedDifference(["B5", "B4"]).rename("NDVI")
+    print("NDVI image info:", ndvi.getInfo())
+
+    if args.export:
+        task = ee.batch.Export.image.toDrive(
+            image=ndvi,
+            description="ndvi_example",
+            folder="earth-engine-exports",
+            fileNamePrefix="ndvi_example",
+            region=aoi.buffer(10000).bounds().getInfo()["coordinates"],
+            scale=30,
+        )
+        task.start()
+        print("Export task started. Check the Earth Engine tasks panel.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve `compute_ndvi.py` with command-line interface and optional export to Google Drive
- update README with new usage instructions

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68569bbfc108832fbe51266d7cd82e4f